### PR TITLE
EXTKeyPathCoding: Change `@keypath` to `$keypath`.

### DIFF
--- a/Tests/EXTKeyPathCodingTest.m
+++ b/Tests/EXTKeyPathCodingTest.m
@@ -24,7 +24,7 @@
     NSURL *URL = [NSURL URLWithString:@"http://www.google.com:8080/search?q=foo"];
     XCTAssertNotNil(URL, @"");
 
-    NSString *path = @keypath(URL.port);
+    NSString *path = $keypath(URL.port);
     XCTAssertEqualObjects(path, @"port", @"");
 }
 
@@ -32,44 +32,44 @@
     NSURL *URL = [NSURL URLWithString:@"http://www.google.com:8080/search?q=foo"];
     XCTAssertNotNil(URL, @"");
 
-    NSString *path = @keypath(URL.port.stringValue);
+    NSString *path = $keypath(URL.port.stringValue);
     XCTAssertEqualObjects(path, @"port.stringValue", @"");
 
-    path = @keypath(URL.port, stringValue);
+    path = $keypath(URL.port, stringValue);
     XCTAssertEqualObjects(path, @"stringValue", @"");
 }
 
 - (void)testClassKeyPath {
-    NSString *path = @keypath(NSString.class.description);
+    NSString *path = $keypath(NSString.class.description);
     XCTAssertEqualObjects(path, @"class.description", @"");
 
-    path = @keypath(NSString.class, description);
+    path = $keypath(NSString.class, description);
     XCTAssertEqualObjects(path, @"description", @"");
 }
 
 - (void)testMyClassInstanceKeyPath {
-    NSString *path = @keypath(MyClass.new, someUniqueProperty);
+    NSString *path = $keypath(MyClass.new, someUniqueProperty);
     XCTAssertEqualObjects(path, @"someUniqueProperty", @"");
 
     MyClass *obj = [[MyClass alloc] init];
 
-    path = @keypath(obj.someUniqueProperty);
+    path = $keypath(obj.someUniqueProperty);
     XCTAssertEqualObjects(path, @"someUniqueProperty", @"");
 }
 
 - (void)testMyClassClassKeyPath {
-    NSString *path = @keypath(MyClass, classProperty);
+    NSString *path = $keypath(MyClass, classProperty);
     XCTAssertEqualObjects(path, @"classProperty", @"");
 }
 
 - (void)testCollectionInstanceKeyPath {
 	MyClass *obj = [[MyClass alloc] init];
-	NSString *path = @collectionKeypath(obj.collection, MyClass.new, someUniqueProperty);
+	NSString *path = $collectionKeypath(obj.collection, MyClass.new, someUniqueProperty);
 	XCTAssertEqualObjects(path, @"collection.someUniqueProperty", @"");
 }
 
 - (void)testCollectionClassKeyPath {
-	NSString *path = @collectionKeypath(MyClass.new, collection, MyClass.new, someUniqueProperty);
+	NSString *path = $collectionKeypath(MyClass.new, collection, MyClass.new, someUniqueProperty);
 	XCTAssertEqualObjects(path, @"collection.someUniqueProperty", @"");
 }
 

--- a/Tests/EXTKeypathWeakWarningTest.m
+++ b/Tests/EXTKeypathWeakWarningTest.m
@@ -24,8 +24,8 @@
 @implementation EXTKeypathWeakWarningTest
 
 - (void)testWarningIsNotEmitted {
-    __unused NSString *keypath = @keypath(EXTClassWithWeakProperty.new, property);
-    __unused NSString *keypath2 = @keypath(EXTClassWithWeakProperty.new, property);
+    __unused NSString *keypath = $keypath(EXTClassWithWeakProperty.new, property);
+    __unused NSString *keypath2 = $keypath(EXTClassWithWeakProperty.new, property);
 }
 
 @end

--- a/extobjc/EXTKeyPathCoding.h
+++ b/extobjc/EXTKeyPathCoding.h
@@ -14,18 +14,18 @@
 #import "metamacros.h"
 
 /**
- * \@keypath allows compile-time verification of key paths. Given a real object
+ * \$keypath allows compile-time verification of key paths. Given a real object
  * receiver and key path:
  *
  * @code
 
-NSString *UTF8StringPath = @keypath(str.lowercaseString.UTF8String);
+NSString *UTF8StringPath = $keypath(str.lowercaseString.UTF8String);
 // => @"lowercaseString.UTF8String"
 
-NSString *versionPath = @keypath(NSObject, version);
+NSString *versionPath = $keypath(NSObject, version);
 // => @"version"
 
-NSString *lowercaseStringPath = @keypath(NSString.new, lowercaseString);
+NSString *lowercaseStringPath = $keypath(NSString.new, lowercaseString);
 // => @"lowercaseString"
 
  * @endcode
@@ -36,12 +36,12 @@ NSString *lowercaseStringPath = @keypath(NSString.new, lowercaseString);
  * In addition to simply creating a key path, this macro ensures that the key
  * path is valid at compile-time (causing a syntax error if not), and supports
  * refactoring, such that changing the name of the property will also update any
- * uses of \@keypath.
+ * uses of \$keypath.
  */
-#define keypath(...) \
+#define $keypath(...) \
     _Pragma("clang diagnostic push") \
     _Pragma("clang diagnostic ignored \"-Warc-repeated-use-of-weak\"") \
-    metamacro_if_eq(1, metamacro_argcount(__VA_ARGS__))(keypath1(__VA_ARGS__))(keypath2(__VA_ARGS__)) \
+    (NSString *)@(metamacro_if_eq(1, metamacro_argcount(__VA_ARGS__))(keypath1(__VA_ARGS__))(keypath2(__VA_ARGS__))) \
     _Pragma("clang diagnostic pop") \
 
 #define keypath1(PATH) \
@@ -65,11 +65,11 @@ NSString *lowercaseStringPath = @keypath(NSString.new, lowercaseString);
  * @endcode
  *
  */
-#define collectionKeypath(...) \
+#define $collectionKeypath(...) \
     metamacro_if_eq(3, metamacro_argcount(__VA_ARGS__))(collectionKeypath3(__VA_ARGS__))(collectionKeypath4(__VA_ARGS__))
 
-#define collectionKeypath3(PATH, COLLECTION_OBJECT, COLLECTION_PATH) ([[NSString stringWithFormat:@"%s.%s",keypath(PATH), keypath(COLLECTION_OBJECT, COLLECTION_PATH)] UTF8String])
+#define collectionKeypath3(PATH, COLLECTION_OBJECT, COLLECTION_PATH) ([NSString stringWithFormat:@"%@.%@", $keypath(PATH), $keypath(COLLECTION_OBJECT, COLLECTION_PATH)])
 
-#define collectionKeypath4(OBJ, PATH, COLLECTION_OBJECT, COLLECTION_PATH) ([[NSString stringWithFormat:@"%s.%s",keypath(OBJ, PATH), keypath(COLLECTION_OBJECT, COLLECTION_PATH)] UTF8String])
+#define collectionKeypath4(OBJ, PATH, COLLECTION_OBJECT, COLLECTION_PATH) ([NSString stringWithFormat:@"%@.%@", $keypath(OBJ, PATH), $keypath(COLLECTION_OBJECT, COLLECTION_PATH)])
 
 #endif


### PR DESCRIPTION
Xcode 10 changed the return value of the box operator (`@`) to return
a `nullable NSString *` instead of `NSString *` when the parameter is
`char *`. This change makes the `@keypath` macro return nullable value
as well.

When enabling a compiler warning to warn whenever a nullable variable
pointer is set to a non-nullable variable, many warning are thrown due
to the above change.

One solution is to surround each `@keypath` usage with `nn()`, but
that would be very annoying. Since the warning's source is outside the
original macro, it cannot be fixed inside the macro while still using
`@`. The solution with the least amount of change is this.