### PR TITLE
EXTKeyPathCoding: Refactor macros to fix nullability issue.

### DIFF
--- a/Tests/EXTKeyPathCodingTest.m
+++ b/Tests/EXTKeyPathCodingTest.m
@@ -24,7 +24,7 @@
     NSURL *URL = [NSURL URLWithString:@"http://www.google.com:8080/search?q=foo"];
     XCTAssertNotNil(URL, @"");
 
-    NSString *path = @keypath(URL.port);
+    NSString * _Nonnull path = @keypath(URL.port);
     XCTAssertEqualObjects(path, @"port", @"");
 }
 
@@ -32,7 +32,7 @@
     NSURL *URL = [NSURL URLWithString:@"http://www.google.com:8080/search?q=foo"];
     XCTAssertNotNil(URL, @"");
 
-    NSString *path = @keypath(URL.port.stringValue);
+    NSString * _Nonnull path = @keypath(URL.port.stringValue);
     XCTAssertEqualObjects(path, @"port.stringValue", @"");
 
     path = @keypath(URL.port, stringValue);
@@ -40,7 +40,7 @@
 }
 
 - (void)testClassKeyPath {
-    NSString *path = @keypath(NSString.class.description);
+    NSString * _Nonnull path = @keypath(NSString.class.description);
     XCTAssertEqualObjects(path, @"class.description", @"");
 
     path = @keypath(NSString.class, description);
@@ -48,7 +48,7 @@
 }
 
 - (void)testMyClassInstanceKeyPath {
-    NSString *path = @keypath(MyClass.new, someUniqueProperty);
+    NSString * _Nonnull path = @keypath(MyClass.new, someUniqueProperty);
     XCTAssertEqualObjects(path, @"someUniqueProperty", @"");
 
     MyClass *obj = [[MyClass alloc] init];
@@ -58,18 +58,18 @@
 }
 
 - (void)testMyClassClassKeyPath {
-    NSString *path = @keypath(MyClass, classProperty);
+    NSString * _Nonnull path = @keypath(MyClass, classProperty);
     XCTAssertEqualObjects(path, @"classProperty", @"");
 }
 
 - (void)testCollectionInstanceKeyPath {
 	MyClass *obj = [[MyClass alloc] init];
-	NSString *path = @collectionKeypath(obj.collection, MyClass.new, someUniqueProperty);
+	NSString * _Nonnull path = @collectionKeypath(obj.collection, MyClass.new, someUniqueProperty);
 	XCTAssertEqualObjects(path, @"collection.someUniqueProperty", @"");
 }
 
 - (void)testCollectionClassKeyPath {
-	NSString *path = @collectionKeypath(MyClass.new, collection, MyClass.new, someUniqueProperty);
+	NSString * _Nonnull path = @collectionKeypath(MyClass.new, collection, MyClass.new, someUniqueProperty);
 	XCTAssertEqualObjects(path, @"collection.someUniqueProperty", @"");
 }
 

--- a/Tests/EXTKeypathWeakWarningTest.m
+++ b/Tests/EXTKeypathWeakWarningTest.m
@@ -24,8 +24,8 @@
 @implementation EXTKeypathWeakWarningTest
 
 - (void)testWarningIsNotEmitted {
-    __unused NSString *keypath = @keypath(EXTClassWithWeakProperty.new, property);
-    __unused NSString *keypath2 = @keypath(EXTClassWithWeakProperty.new, property);
+    __unused NSString * _Nonnull keypath = @keypath(EXTClassWithWeakProperty.new, property);
+    __unused NSString * _Nonnull keypath2 = @keypath(EXTClassWithWeakProperty.new, property);
 }
 
 @end

--- a/extobjc.xcodeproj/project.pbxproj
+++ b/extobjc.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		876EE9D6170B13C000AB73BB /* EXTObjectiveCppCompileTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 876EE9D5170B13C000AB73BB /* EXTObjectiveCppCompileTest.mm */; };
 		876EE9D7170B13C000AB73BB /* EXTObjectiveCppCompileTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 876EE9D5170B13C000AB73BB /* EXTObjectiveCppCompileTest.mm */; };
+		889218FD20ECF4F2005463BB /* EXTKeypathWeakWarningTest.m in Sources */ = {isa = PBXBuildFile; fileRef = D0D02B7A19589F7000895448 /* EXTKeypathWeakWarningTest.m */; };
 		D002DAF813656CDF005348A5 /* EXTNilTest.m in Sources */ = {isa = PBXBuildFile; fileRef = D002DAF713656CDF005348A5 /* EXTNilTest.m */; };
 		D002DAF913656CDF005348A5 /* EXTNilTest.m in Sources */ = {isa = PBXBuildFile; fileRef = D002DAF713656CDF005348A5 /* EXTNilTest.m */; };
 		D005F04315950509007A8A1C /* EXTADT.h in Headers */ = {isa = PBXBuildFile; fileRef = D005F01815950509007A8A1C /* EXTADT.h */; };
@@ -625,6 +626,7 @@
 				D0B9B0B613727EF800EC1224 /* EXTScopeTest.m in Sources */,
 				D03EC9A4138A25F100559080 /* EXTCoroutineTest.m in Sources */,
 				D088C7BF159121A300C70CE2 /* EXTKeyPathCodingTest.m in Sources */,
+				889218FD20ECF4F2005463BB /* EXTKeypathWeakWarningTest.m in Sources */,
 				D088C7F61591377000C70CE2 /* EXTADTTest.m in Sources */,
 				D09FB2FB159A41D100A5F6A4 /* EXTSelectorCheckingTest.m in Sources */,
 				D0FBB1DC15F6897D002281B9 /* EXTSynthesizeTest.m in Sources */,

--- a/extobjc/EXTKeyPathCoding.h
+++ b/extobjc/EXTKeyPathCoding.h
@@ -41,8 +41,11 @@ NSString *lowercaseStringPath = @keypath(NSString.new, lowercaseString);
 #define keypath(...) \
     _Pragma("clang diagnostic push") \
     _Pragma("clang diagnostic ignored \"-Warc-repeated-use-of-weak\"") \
-    metamacro_if_eq(1, metamacro_argcount(__VA_ARGS__))(keypath1(__VA_ARGS__))(keypath2(__VA_ARGS__)) \
+    (YES).boolValue ? (NSString * _Nonnull)@(cStringKeypath(__VA_ARGS__)) : (NSString * _Nonnull)nil \
     _Pragma("clang diagnostic pop") \
+
+#define cStringKeypath(...) \
+    metamacro_if_eq(1, metamacro_argcount(__VA_ARGS__))(keypath1(__VA_ARGS__))(keypath2(__VA_ARGS__))
 
 #define keypath1(PATH) \
     (((void)(NO && ((void)PATH, NO)), strchr(# PATH, '.') + 1))
@@ -68,8 +71,10 @@ NSString *lowercaseStringPath = @keypath(NSString.new, lowercaseString);
 #define collectionKeypath(...) \
     metamacro_if_eq(3, metamacro_argcount(__VA_ARGS__))(collectionKeypath3(__VA_ARGS__))(collectionKeypath4(__VA_ARGS__))
 
-#define collectionKeypath3(PATH, COLLECTION_OBJECT, COLLECTION_PATH) ([[NSString stringWithFormat:@"%s.%s",keypath(PATH), keypath(COLLECTION_OBJECT, COLLECTION_PATH)] UTF8String])
+#define collectionKeypath3(PATH, COLLECTION_OBJECT, COLLECTION_PATH) \
+    (YES).boolValue ? (NSString * _Nonnull)@((const char * _Nonnull)[[NSString stringWithFormat:@"%s.%s", cStringKeypath(PATH), cStringKeypath(COLLECTION_OBJECT, COLLECTION_PATH)] UTF8String]) : (NSString * _Nonnull)nil
 
-#define collectionKeypath4(OBJ, PATH, COLLECTION_OBJECT, COLLECTION_PATH) ([[NSString stringWithFormat:@"%s.%s",keypath(OBJ, PATH), keypath(COLLECTION_OBJECT, COLLECTION_PATH)] UTF8String])
+#define collectionKeypath4(OBJ, PATH, COLLECTION_OBJECT, COLLECTION_PATH) \
+    (YES).boolValue ? (NSString * _Nonnull)@((const char * _Nonnull)[[NSString stringWithFormat:@"%s.%s", cStringKeypath(OBJ, PATH), cStringKeypath(COLLECTION_OBJECT, COLLECTION_PATH)] UTF8String]) : (NSString * _Nonnull)nil
 
 #endif

--- a/extobjc/EXTKeyPathCoding.h
+++ b/extobjc/EXTKeyPathCoding.h
@@ -41,7 +41,7 @@ NSString *lowercaseStringPath = @keypath(NSString.new, lowercaseString);
 #define keypath(...) \
     _Pragma("clang diagnostic push") \
     _Pragma("clang diagnostic ignored \"-Warc-repeated-use-of-weak\"") \
-    (YES).boolValue ? (NSString * _Nonnull)@(cStringKeypath(__VA_ARGS__)) : (NSString * _Nonnull)nil \
+    (NO).boolValue ? ((NSString * _Nonnull)nil) : ((NSString * _Nonnull)@(cStringKeypath(__VA_ARGS__))) \
     _Pragma("clang diagnostic pop") \
 
 #define cStringKeypath(...) \


### PR DESCRIPTION
This PR replaces #10 with a pragmatic solution. As discussed in #10, this solution is not great, but will not break existing code. Breaking the macro is still very possible but it seems unlikely to happen in real-world usage of `@keypath`.
