### PR TITLE
EXTKeyPathCoding.h: Fix analyizer nullability detection.

### DIFF
--- a/Tests/EXTKeyPathCodingTest.m
+++ b/Tests/EXTKeyPathCodingTest.m
@@ -73,6 +73,11 @@
 	XCTAssertEqualObjects(path, @"collection.someUniqueProperty", @"");
 }
 
+- (void)testKeyPathInArray {
+  // This triggers the static analyzer if the expression returns nil.
+  NSArray *array __unused = @[@keypath(NSString, class)];
+}
+
 @end
 
 @implementation MyClass

--- a/extobjc/EXTKeyPathCoding.h
+++ b/extobjc/EXTKeyPathCoding.h
@@ -41,7 +41,7 @@ NSString *lowercaseStringPath = @keypath(NSString.new, lowercaseString);
 #define keypath(...) \
     _Pragma("clang diagnostic push") \
     _Pragma("clang diagnostic ignored \"-Warc-repeated-use-of-weak\"") \
-    (NO).boolValue ? ((NSString * _Nonnull)nil) : ((NSString * _Nonnull)@(cStringKeypath(__VA_ARGS__))) \
+    (NO).boolValue ? @"" : ((NSString * _Nonnull)@(cStringKeypath(__VA_ARGS__))) \
     _Pragma("clang diagnostic pop") \
 
 #define cStringKeypath(...) \


### PR DESCRIPTION
Xcode 10's static analyzer sees through the _Nonnull cast and alerts
about potential nullability. Instead an actual string is used.