### PR TITLE
.gitmodules: use HTTPS address for the Configuration submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Configuration"]
 	path = Configuration
-	url = git://github.com/jspahrsummers/xcconfigs.git
+	url = https://github.com/jspahrsummers/xcconfigs.git


### PR DESCRIPTION
This fixes a long-standing performance that we have while cloning this
repo. This change will save about 40 seonds in each repo clone.