### PR TITLE
EXTKeyPathCoding: decrease runtime cost of keypath macros.

### DIFF
--- a/extobjc/EXTKeyPathCoding.h
+++ b/extobjc/EXTKeyPathCoding.h
@@ -41,17 +41,17 @@ NSString *lowercaseStringPath = @keypath(NSString.new, lowercaseString);
 #define keypath(...) \
     _Pragma("clang diagnostic push") \
     _Pragma("clang diagnostic ignored \"-Warc-repeated-use-of-weak\"") \
-    (NO).boolValue ? @"" : ((NSString * _Nonnull)@(cStringKeypath(__VA_ARGS__))) \
+    keypath_va(__VA_ARGS__) \
     _Pragma("clang diagnostic pop") \
 
-#define cStringKeypath(...) \
+#define keypath_va(...) \
     metamacro_if_eq(1, metamacro_argcount(__VA_ARGS__))(keypath1(__VA_ARGS__))(keypath2(__VA_ARGS__))
 
 #define keypath1(PATH) \
-    (((void)(NO && ((void)PATH, NO)), strchr(# PATH, '.') + 1))
+    selector(alloc) ? @(strchr(#PATH, '.') + 1) : (NSString * _Nonnull)(YES ? @"" : ({((void)PATH); (NSString * _Nonnull)nil;}))
 
 #define keypath2(OBJ, PATH) \
-    (((void)(NO && ((void)OBJ.PATH, NO)), # PATH))
+    selector(alloc) ? @#PATH : (NSString * _Nonnull)(YES ? @"" : ({((void)OBJ.PATH); (NSString * _Nonnull)nil;}))
 
 /**
  * \@collectionKeypath allows compile-time verification of key paths across collections NSArray/NSSet etc. Given a real object
@@ -72,9 +72,9 @@ NSString *lowercaseStringPath = @keypath(NSString.new, lowercaseString);
     metamacro_if_eq(3, metamacro_argcount(__VA_ARGS__))(collectionKeypath3(__VA_ARGS__))(collectionKeypath4(__VA_ARGS__))
 
 #define collectionKeypath3(PATH, COLLECTION_OBJECT, COLLECTION_PATH) \
-    (YES).boolValue ? (NSString * _Nonnull)@((const char * _Nonnull)[[NSString stringWithFormat:@"%s.%s", cStringKeypath(PATH), cStringKeypath(COLLECTION_OBJECT, COLLECTION_PATH)] UTF8String]) : (NSString * _Nonnull)nil
+    selector(alloc) ? (NSString * _Nonnull)@((const char * _Nonnull)[[NSString stringWithFormat:@"%@.%@", @keypath_va(PATH), @keypath_va(COLLECTION_OBJECT, COLLECTION_PATH)] UTF8String]) : (NSString * _Nonnull)nil
 
 #define collectionKeypath4(OBJ, PATH, COLLECTION_OBJECT, COLLECTION_PATH) \
-    (YES).boolValue ? (NSString * _Nonnull)@((const char * _Nonnull)[[NSString stringWithFormat:@"%s.%s", cStringKeypath(OBJ, PATH), cStringKeypath(COLLECTION_OBJECT, COLLECTION_PATH)] UTF8String]) : (NSString * _Nonnull)nil
+    selector(alloc) ? (NSString * _Nonnull)@((const char * _Nonnull)[[NSString stringWithFormat:@"%@.%@", @keypath_va(OBJ, PATH), @keypath_va(COLLECTION_OBJECT, COLLECTION_PATH)] UTF8String]) : (NSString * _Nonnull)nil
 
 #endif


### PR DESCRIPTION
The keypath macros `@keypath` and `@collectionKeypath` used to have a
non negligible runtime overhead, as they allocated Obj-C objects and
sent messages although they are only used to ensure compile-time safety.

For example, let's take a look at `@keypath` macro with two arguments
(the common case). The code `@keypath(foo, bar)` expands to:

```
@(NO).boolValue ? @"" :
  ((NSString * _Nonnull)@((((void)(NO && ((void)foo.bar, NO)), "bar"))))
```

Or, after compilation with `-Os`, the code looks like this:
```
NSString *result;
if ([[NSNumber numberWithBool:NO] boolValue]) {
  result = @"";
} else {
  result = [NSString stringWithUTF8String:"baz"];
}
```

This code has two allocations: one for `NSNumber` and one for
`NSString`. Moreover, there's work needs to be done to unbox the `BOOL`
value and to initialize the string (that probably require, for the very
least, to calculate its length).

Additionally, because of the dynamic nature of Obj-C, once there are any
dynamic dispatches, this code cannot be optimized by the compiler (even
if we know that `[[NSNumber numberWithBool:NO] boolValue]` is _always_
false).

To mitigate that, a new formulation of the macro that uses `@selector`
is proposed. The cost of creating a predefined selector is very cheap,
and involves only a single QWORD load (on 64-bit platforms), which is
the pointer to the interned `char *` that represents that selector.

The compiled code for the new macro looks like this:
```
NSString *result = @"baz";
if (!@selector(alloc)) {
  result = @"";
}
```

Which generates less code and is more space efficient and doesn't
contain any message sends, so the compiler can also optimize this away
if needed.